### PR TITLE
feat(review): add comment application functionality with dry-run support

### DIFF
--- a/core/review.py
+++ b/core/review.py
@@ -1,3 +1,4 @@
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -15,7 +16,7 @@ from core.prompts import (
     CODE_REVIEW_SYSTEM,
     CODE_REVIEW_USER_TEMPLATE,
 )
-from utils.common import describe_command_failure, env_int, trim_text_middle
+from utils.common import describe_command_failure, env_int, is_dry_run, trim_text_middle
 from utils.git import git_command
 
 REVIEW_TARGET_WORKTREE = "worktree"
@@ -95,6 +96,10 @@ REVIEWABLE_TEXT_EXTENSIONS = COMMENTABLE_EXTENSIONS | {
     ".yml",
 }
 VALID_COMMENT_PLACEMENTS = {"before", "after"}
+COMMENT_APPLICATION_APPLIED = "applied"
+COMMENT_APPLICATION_DRY_RUN = "dry-run"
+COMMENT_APPLICATION_SKIPPED = "skipped"
+COMMENT_APPLICATION_FAILED = "failed"
 
 
 class ReviewContextError(RuntimeError):
@@ -164,6 +169,38 @@ class CodeReviewExplanation:
                 self.points_to_check,
                 self.risks,
             ]
+        )
+
+
+@dataclass(frozen=True)
+class ReviewCommentApplication:
+    suggestion: ReviewCommentSuggestion
+    status: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ReviewCommentApplicationReport:
+    results: list[ReviewCommentApplication]
+
+    @property
+    def modified_files(self) -> list[str]:
+        return sorted(
+            {
+                result.suggestion.file
+                for result in self.results
+                if result.status == COMMENT_APPLICATION_APPLIED
+            }
+        )
+
+    @property
+    def simulated_files(self) -> list[str]:
+        return sorted(
+            {
+                result.suggestion.file
+                for result in self.results
+                if result.status == COMMENT_APPLICATION_DRY_RUN
+            }
         )
 
 
@@ -407,6 +444,174 @@ def _read_review_file(repo_path: str, relative_file_path: str) -> str:
         return file_path.read_text(encoding="utf-8")
     except UnicodeDecodeError as error:
         raise ReviewContextError(f"File is not valid UTF-8 text: {relative_file_path}") from error
+
+
+def _resolve_comment_file(repo_path: str, relative_file_path: str, allowed_files: set[str]) -> tuple[str, Path]:
+    normalized = _clean_relative_file_path(relative_file_path)
+    if normalized not in allowed_files:
+        raise ReviewContextError(f"File is outside the selected review context: {normalized}")
+    if not is_commentable_source_file(normalized):
+        raise ReviewContextError(f"Refusing to modify unsupported or sensitive file '{normalized}'.")
+
+    repo_root = Path(repo_path).resolve()
+    file_path = (repo_root / normalized).resolve()
+    try:
+        file_path.relative_to(repo_root)
+    except ValueError as error:
+        raise ReviewContextError("Comment file path cannot escape the repository.") from error
+
+    if not file_path.is_file():
+        raise ReviewContextError(f"File not found: {normalized}")
+    return normalized, file_path
+
+
+def _read_source_file(file_path: Path) -> str:
+    try:
+        with file_path.open("r", encoding="utf-8", newline="") as source_file:
+            return source_file.read()
+    except UnicodeDecodeError as error:
+        raise ReviewContextError(f"File is not valid UTF-8 text: {file_path.name}") from error
+
+
+def _write_source_file(file_path: Path, content: str) -> None:
+    with file_path.open("w", encoding="utf-8", newline="") as source_file:
+        source_file.write(content)
+
+
+def _line_indentation(content: str, position: int) -> str:
+    line_start = content.rfind("\n", 0, position) + 1
+    line_end = content.find("\n", line_start)
+    if line_end == -1:
+        line_end = len(content)
+    line = content[line_start:line_end].lstrip("\r")
+    return line[: len(line) - len(line.lstrip(" \t"))]
+
+
+def _next_line_indentation(content: str, position: int, fallback: str) -> str:
+    line_end = content.find("\n", position)
+    if line_end == -1 or line_end + 1 >= len(content):
+        return fallback
+
+    next_start = line_end + 1
+    next_end = content.find("\n", next_start)
+    if next_end == -1:
+        next_end = len(content)
+    next_line = content[next_start:next_end].lstrip("\r")
+    if not next_line.strip():
+        return fallback
+
+    indentation = next_line[: len(next_line) - len(next_line.lstrip(" \t"))]
+    return indentation if len(indentation) > len(fallback) else fallback
+
+
+def _format_comment(comment: str, indentation: str, newline: str) -> str:
+    dedented = textwrap.dedent(comment).strip()
+    lines = dedented.splitlines()
+    return newline.join(f"{indentation}{line.rstrip()}" if line.strip() else "" for line in lines)
+
+
+def _insert_comment(content: str, suggestion: ReviewCommentSuggestion) -> tuple[str | None, str]:
+    anchor = suggestion.anchor.strip()
+    comment = suggestion.comment.strip()
+    if not anchor or not comment:
+        return None, "Anchor or comment is empty."
+    if comment in content:
+        return None, "Comment already exists in the file."
+
+    occurrence_count = content.count(anchor)
+    if occurrence_count == 0:
+        return None, "Anchor was not found."
+    if occurrence_count > 1:
+        return None, f"Anchor is ambiguous ({occurrence_count} matches)."
+
+    anchor_start = content.find(anchor)
+    anchor_end = anchor_start + len(anchor)
+    newline = "\r\n" if "\r\n" in content else "\n"
+    indentation = _line_indentation(content, anchor_start)
+
+    if suggestion.placement == "after":
+        indentation = _next_line_indentation(content, anchor_end, indentation)
+        line_end = content.find("\n", anchor_end)
+        if line_end == -1:
+            formatted = _format_comment(comment, indentation, newline)
+            separator = "" if content.endswith(("\n", "\r")) else newline
+            return f"{content}{separator}{formatted}", "Comment inserted after the anchor."
+
+        insert_at = line_end + 1
+        formatted = _format_comment(comment, indentation, newline)
+        return (
+            f"{content[:insert_at]}{formatted}{newline}{content[insert_at:]}",
+            "Comment inserted after the anchor.",
+        )
+
+    line_start = content.rfind("\n", 0, anchor_start) + 1
+    formatted = _format_comment(comment, indentation, newline)
+    return (
+        f"{content[:line_start]}{formatted}{newline}{content[line_start:]}",
+        "Comment inserted before the anchor.",
+    )
+
+
+def apply_review_comments(
+    repo_path: str,
+    context: ReviewContext,
+    plan: ReviewCommentPlan,
+) -> ReviewCommentApplicationReport:
+    allowed_files = {
+        _clean_relative_file_path(file_name)
+        for file_name in context.files
+        if is_commentable_source_file(file_name)
+    }
+    cached_contents: dict[Path, str] = {}
+    results: list[ReviewCommentApplication] = []
+
+    for suggestion in plan.comments:
+        try:
+            normalized, file_path = _resolve_comment_file(repo_path, suggestion.file, allowed_files)
+            content = cached_contents.get(file_path)
+            if content is None:
+                content = _read_source_file(file_path)
+
+            updated_content, message = _insert_comment(content, suggestion)
+            if updated_content is None:
+                results.append(
+                    ReviewCommentApplication(
+                        suggestion=suggestion,
+                        status=COMMENT_APPLICATION_SKIPPED,
+                        message=message,
+                    )
+                )
+                continue
+
+            cached_contents[file_path] = updated_content
+            if is_dry_run():
+                results.append(
+                    ReviewCommentApplication(
+                        suggestion=suggestion,
+                        status=COMMENT_APPLICATION_DRY_RUN,
+                        message=f"Would update {normalized}. {message}",
+                    )
+                )
+                continue
+
+            _write_source_file(file_path, updated_content)
+            results.append(
+                ReviewCommentApplication(
+                    suggestion=suggestion,
+                    status=COMMENT_APPLICATION_APPLIED,
+                    message=message,
+                )
+            )
+        except (OSError, ReviewContextError) as error:
+            results.append(
+                ReviewCommentApplication(
+                    suggestion=suggestion,
+                    status=COMMENT_APPLICATION_FAILED,
+                    message=str(error),
+                )
+            )
+
+    return ReviewCommentApplicationReport(results=results)
 
 
 def _build_file_context(repo_path: str, relative_file_path: str) -> ReviewContext:

--- a/run.py
+++ b/run.py
@@ -148,7 +148,12 @@ def render_main_menu(
     table.add_row("1", "Auto Commit", "Scan repositories, build commit messages, then commit/push after confirmation.", "[green]Ready[/]")
     table.add_row("2", "Merge", "Create and auto-merge release PRs into resolved base branches.", "[green]Ready[/]")
     table.add_row("3", "Review Code", "Explain selected code context in French without changing files.", "[cyan]Ready[/]")
-    table.add_row("4", "Comment Code", "Preview AI-assisted source comments for selected code.", "[cyan]Preview[/]")
+    table.add_row(
+        "4",
+        "Comment Code",
+        "Preview and optionally apply AI-assisted source comments.",
+        "[green]Ready[/]",
+    )
     table.add_row("5", "Changelog", "Update changelogs from Conventional Commits.", "[green]Ready[/]")
     table.add_row("6", "Sync", "Checkout and fast-forward local base branches.", "[green]Ready[/]")
     table.add_row("q", "Quit", "Leave the tool without running another workflow.", "[dim]Exit[/]")
@@ -386,12 +391,70 @@ def render_comment_plan(repo_name: str, context, plan) -> None:
 
     console.print(
         Panel(
-            "Preview only. No source file was modified.",
-            title="[bold magenta]Safe Mode[/]",
+            "Review each suggestion before applying. No source file has been modified yet.",
+            title="[bold magenta]Confirmation Required[/]",
             border_style="magenta",
             padding=(1, 2),
         )
     )
+
+
+def render_comment_application_report(report) -> None:
+    table = Table(
+        box=box.ROUNDED,
+        show_lines=True,
+        header_style="bold cyan",
+        border_style="bright_black",
+    )
+    table.add_column("File", style="bold white", no_wrap=True)
+    table.add_column("Status", justify="center", no_wrap=True)
+    table.add_column("Details", style="white")
+
+    status_styles = {
+        "applied": "green",
+        "dry-run": "cyan",
+        "skipped": "yellow",
+        "failed": "red",
+    }
+    for result in report.results:
+        style = status_styles.get(result.status, "white")
+        table.add_row(
+            result.suggestion.file,
+            f"[{style}]{result.status.upper()}[/]",
+            result.message,
+        )
+
+    console.print(table)
+
+    if report.modified_files:
+        files = ", ".join(report.modified_files)
+        console.print(
+            Panel(
+                f"Updated source files: {files}",
+                title="[bold green]Comments Applied[/]",
+                border_style="green",
+                padding=(1, 2),
+            )
+        )
+    elif report.simulated_files:
+        files = ", ".join(report.simulated_files)
+        console.print(
+            Panel(
+                f"Dry-run only. Files that would be updated: {files}",
+                title="[bold cyan]Simulation Complete[/]",
+                border_style="cyan",
+                padding=(1, 2),
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                "No source file was modified.",
+                title="[bold yellow]No Changes Applied[/]",
+                border_style="yellow",
+                padding=(1, 2),
+            )
+        )
 
 
 def run_review_workflow(root_dirs: list[str]) -> None:
@@ -449,7 +512,13 @@ def run_review_workflow(root_dirs: list[str]) -> None:
 
 def run_comment_workflow(root_dirs: list[str]) -> None:
     from core.repositories import iter_git_repositories
-    from core.review import ReviewContextError, collect_review_context, generate_review_comments
+    from core.review import (
+        ReviewContextError,
+        apply_review_comments,
+        collect_review_context,
+        generate_review_comments,
+    )
+    from utils.console import ask_yes_no
 
     section_title("Comment Code", "💬")
 
@@ -496,6 +565,22 @@ def run_comment_workflow(root_dirs: list[str]) -> None:
         plan = generate_review_comments(repo_name, context)
 
     render_comment_plan(repo_name, context, plan)
+
+    if not plan.has_comments:
+        return
+    if not ask_yes_no("Apply these comments to source files?", default="n"):
+        console.print(
+            Panel(
+                "Comment application cancelled. No source file was modified.",
+                title="[bold yellow]Cancelled[/]",
+                border_style="yellow",
+                padding=(1, 2),
+            )
+        )
+        return
+
+    report = apply_review_comments(repo_path, context, plan)
+    render_comment_application_report(report)
 
 
 def run_selected_action(

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from unittest.mock import call, patch
 
 from core.review import (
+    COMMENT_APPLICATION_APPLIED,
+    COMMENT_APPLICATION_DRY_RUN,
+    COMMENT_APPLICATION_FAILED,
+    COMMENT_APPLICATION_SKIPPED,
     CodeReviewFormatError,
     REVIEW_TARGET_FILE,
     DEFAULT_REVIEW_DIFF_MAX_CHARS,
@@ -16,7 +20,11 @@ from core.review import (
     CodeReviewExplanation,
     ReviewContext,
     ReviewContextError,
+    ReviewCommentApplicationReport,
     ReviewCommentFormatError,
+    ReviewCommentPlan,
+    ReviewCommentSuggestion,
+    apply_review_comments,
     build_code_review_explanation,
     build_review_comment_plan,
     collect_review_context,
@@ -436,6 +444,134 @@ class ReviewCommentGenerationTests(unittest.TestCase):
 
         self.assertEqual(plan.summary, "No AI code comments generated.")
         self.assertFalse(plan.has_comments)
+
+
+class ReviewCommentApplicationTests(unittest.TestCase):
+    def _context(self, repo_path: str, files: list[str] | None = None) -> ReviewContext:
+        return ReviewContext(
+            repo_path=repo_path,
+            target=REVIEW_TARGET_WORKTREE,
+            label="worktree changes",
+            files=files or ["src/app.py"],
+            diff="diff --git",
+        )
+
+    def _plan(
+        self,
+        *,
+        file_name: str = "src/app.py",
+        anchor: str = "def build_payload():",
+        placement: str = "before",
+        comment: str = "# Build the normalized payload before the API call.",
+    ) -> ReviewCommentPlan:
+        return ReviewCommentPlan(
+            summary="Comment plan",
+            comments=[
+                ReviewCommentSuggestion(
+                    file=file_name,
+                    anchor=anchor,
+                    placement=placement,
+                    comment=comment,
+                    reason="Clarifies non-obvious behavior.",
+                )
+            ],
+        )
+
+    def test_apply_review_comments_inserts_comment_before_unique_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "src" / "app.py"
+            file_path.parent.mkdir()
+            file_path.write_text("def build_payload():\n    return {}\n", encoding="utf-8")
+
+            with patch("core.review.is_dry_run", return_value=False):
+                report = apply_review_comments(tmp_dir, self._context(tmp_dir), self._plan())
+
+            content = file_path.read_text(encoding="utf-8")
+
+        self.assertIsInstance(report, ReviewCommentApplicationReport)
+        self.assertEqual(report.results[0].status, COMMENT_APPLICATION_APPLIED)
+        self.assertEqual(report.modified_files, ["src/app.py"])
+        self.assertTrue(content.startswith("# Build the normalized payload"))
+
+    def test_apply_review_comments_inserts_after_anchor_using_next_line_indentation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "src" / "app.py"
+            file_path.parent.mkdir()
+            file_path.write_text("def build_payload():\n    return {}\n", encoding="utf-8")
+            plan = self._plan(
+                placement="after",
+                comment="# Keep normalization inside this function.",
+            )
+
+            with patch("core.review.is_dry_run", return_value=False):
+                report = apply_review_comments(tmp_dir, self._context(tmp_dir), plan)
+
+            content = file_path.read_text(encoding="utf-8")
+
+        self.assertEqual(report.results[0].status, COMMENT_APPLICATION_APPLIED)
+        self.assertIn(
+            "def build_payload():\n    # Keep normalization inside this function.\n    return {}",
+            content,
+        )
+
+    def test_apply_review_comments_dry_run_does_not_write_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "src" / "app.py"
+            file_path.parent.mkdir()
+            original = "def build_payload():\n    return {}\n"
+            file_path.write_text(original, encoding="utf-8")
+
+            with patch("core.review.is_dry_run", return_value=True):
+                report = apply_review_comments(tmp_dir, self._context(tmp_dir), self._plan())
+
+            content = file_path.read_text(encoding="utf-8")
+
+        self.assertEqual(content, original)
+        self.assertEqual(report.results[0].status, COMMENT_APPLICATION_DRY_RUN)
+        self.assertEqual(report.simulated_files, ["src/app.py"])
+
+    def test_apply_review_comments_skips_missing_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "src" / "app.py"
+            file_path.parent.mkdir()
+            original = "def other_function():\n    return {}\n"
+            file_path.write_text(original, encoding="utf-8")
+
+            with patch("core.review.is_dry_run", return_value=False):
+                report = apply_review_comments(tmp_dir, self._context(tmp_dir), self._plan())
+
+            content = file_path.read_text(encoding="utf-8")
+
+        self.assertEqual(content, original)
+        self.assertEqual(report.results[0].status, COMMENT_APPLICATION_SKIPPED)
+        self.assertIn("not found", report.results[0].message)
+
+    def test_apply_review_comments_skips_ambiguous_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "src" / "app.py"
+            file_path.parent.mkdir()
+            original = "value = normalize()\nvalue = normalize()\n"
+            file_path.write_text(original, encoding="utf-8")
+            plan = self._plan(anchor="value = normalize()")
+
+            with patch("core.review.is_dry_run", return_value=False):
+                report = apply_review_comments(tmp_dir, self._context(tmp_dir), plan)
+
+        self.assertEqual(report.results[0].status, COMMENT_APPLICATION_SKIPPED)
+        self.assertIn("ambiguous", report.results[0].message)
+
+    def test_apply_review_comments_rejects_file_outside_selected_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = Path(tmp_dir) / "src" / "other.py"
+            file_path.parent.mkdir()
+            file_path.write_text("def build_payload():\n    return {}\n", encoding="utf-8")
+            plan = self._plan(file_name="src/other.py")
+
+            with patch("core.review.is_dry_run", return_value=False):
+                report = apply_review_comments(tmp_dir, self._context(tmp_dir), plan)
+
+        self.assertEqual(report.results[0].status, COMMENT_APPLICATION_FAILED)
+        self.assertIn("outside the selected review context", report.results[0].message)
 
 
 class CodeReviewExplanationTests(unittest.TestCase):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,7 +8,15 @@ from unittest.mock import patch
 
 from rich.console import Console
 
-from core.review import CodeReviewExplanation, ReviewCommentPlan, ReviewCommentSuggestion, ReviewContext
+from core.review import (
+    COMMENT_APPLICATION_APPLIED,
+    CodeReviewExplanation,
+    ReviewCommentApplication,
+    ReviewCommentApplicationReport,
+    ReviewCommentPlan,
+    ReviewCommentSuggestion,
+    ReviewContext,
+)
 import run
 
 
@@ -47,7 +55,7 @@ class RunConfigTests(unittest.TestCase):
         self.assertIn("--dry-run", help_text)
         self.assertIn("--prod", help_text)
 
-    def test_render_main_menu_includes_review_placeholder_entry(self) -> None:
+    def test_render_main_menu_includes_ready_review_and_comment_entries(self) -> None:
         buffer = io.StringIO()
         test_console = Console(file=buffer, force_terminal=False, color_system=None, width=120)
 
@@ -63,7 +71,7 @@ class RunConfigTests(unittest.TestCase):
         self.assertIn("Dev Tools Control Deck", output)
         self.assertIn("Review Code", output)
         self.assertIn("Comment Code", output)
-        self.assertIn("Preview", output)
+        self.assertIn("optionally apply", output)
 
     def test_ask_main_action_returns_prompt_choice(self) -> None:
         with patch("run.Prompt.ask", return_value="3") as prompt:
@@ -164,7 +172,35 @@ class RunConfigTests(unittest.TestCase):
         output = buffer.getvalue()
         self.assertIn("Comment Preview", output)
         self.assertIn("Suggested Comment 1", output)
-        self.assertIn("Preview only", output)
+        self.assertIn("Confirmation Required", output)
+
+    def test_render_comment_application_report_outputs_modified_files(self) -> None:
+        buffer = io.StringIO()
+        test_console = Console(file=buffer, force_terminal=False, color_system=None, width=120)
+        suggestion = ReviewCommentSuggestion(
+            file="src/app.ts",
+            anchor="function buildPayload(input) {",
+            placement="before",
+            comment="// Normalize before signing.",
+            reason="Order-sensitive behavior.",
+        )
+        report = ReviewCommentApplicationReport(
+            results=[
+                ReviewCommentApplication(
+                    suggestion=suggestion,
+                    status=COMMENT_APPLICATION_APPLIED,
+                    message="Comment inserted before the anchor.",
+                )
+            ]
+        )
+
+        with patch("run.console", test_console):
+            run.render_comment_application_report(report)
+
+        output = buffer.getvalue()
+        self.assertIn("APPLIED", output)
+        self.assertIn("Comments Applied", output)
+        self.assertIn("src/app.ts", output)
 
     def test_run_review_workflow_collects_generates_and_renders_explanation(self) -> None:
         context = ReviewContext(
@@ -250,6 +286,121 @@ class RunConfigTests(unittest.TestCase):
         collect_review_context.assert_called_once_with("/tmp/repo", "worktree", None)
         generate_review_comments.assert_called_once_with("repo", context)
         render_comment_plan.assert_called_once_with("repo", context, plan)
+
+    def test_run_comment_workflow_applies_confirmed_comments(self) -> None:
+        context = ReviewContext(
+            repo_path="/tmp/repo",
+            target="worktree",
+            label="worktree changes",
+            files=["src/app.ts"],
+            diff="diff --git",
+        )
+        suggestion = ReviewCommentSuggestion(
+            file="src/app.ts",
+            anchor="function buildPayload(input) {",
+            placement="before",
+            comment="// Normalize before signing.",
+            reason="Order-sensitive behavior.",
+        )
+        plan = ReviewCommentPlan(summary="Summary", comments=[suggestion])
+        report = ReviewCommentApplicationReport(
+            results=[
+                ReviewCommentApplication(
+                    suggestion=suggestion,
+                    status=COMMENT_APPLICATION_APPLIED,
+                    message="Comment inserted before the anchor.",
+                )
+            ]
+        )
+
+        with patch(
+            "core.repositories.iter_git_repositories",
+            return_value=[("repo", "/tmp/repo")],
+        ), patch(
+            "run.ask_review_repository",
+            return_value=("repo", "/tmp/repo"),
+        ), patch(
+            "run.ask_review_target",
+            return_value=("worktree", None),
+        ), patch(
+            "core.review.collect_review_context",
+            return_value=context,
+        ), patch(
+            "core.review.generate_review_comments",
+            return_value=plan,
+        ), patch(
+            "core.review.apply_review_comments",
+            return_value=report,
+        ) as apply_review_comments, patch(
+            "utils.console.ask_yes_no",
+            return_value=True,
+        ) as ask_yes_no, patch(
+            "run.render_comment_plan"
+        ), patch(
+            "run.render_comment_application_report"
+        ) as render_comment_application_report, patch(
+            "run.console.status",
+            return_value=nullcontext(),
+        ), patch("run.section_title"):
+            run.run_comment_workflow(["/tmp/root"])
+
+        ask_yes_no.assert_called_once_with(
+            "Apply these comments to source files?",
+            default="n",
+        )
+        apply_review_comments.assert_called_once_with("/tmp/repo", context, plan)
+        render_comment_application_report.assert_called_once_with(report)
+
+    def test_run_comment_workflow_does_not_apply_cancelled_comments(self) -> None:
+        context = ReviewContext(
+            repo_path="/tmp/repo",
+            target="worktree",
+            label="worktree changes",
+            files=["src/app.ts"],
+            diff="diff --git",
+        )
+        plan = ReviewCommentPlan(
+            summary="Summary",
+            comments=[
+                ReviewCommentSuggestion(
+                    file="src/app.ts",
+                    anchor="function buildPayload(input) {",
+                    placement="before",
+                    comment="// Normalize before signing.",
+                    reason="Order-sensitive behavior.",
+                )
+            ],
+        )
+
+        with patch(
+            "core.repositories.iter_git_repositories",
+            return_value=[("repo", "/tmp/repo")],
+        ), patch(
+            "run.ask_review_repository",
+            return_value=("repo", "/tmp/repo"),
+        ), patch(
+            "run.ask_review_target",
+            return_value=("worktree", None),
+        ), patch(
+            "core.review.collect_review_context",
+            return_value=context,
+        ), patch(
+            "core.review.generate_review_comments",
+            return_value=plan,
+        ), patch(
+            "core.review.apply_review_comments",
+        ) as apply_review_comments, patch(
+            "utils.console.ask_yes_no",
+            return_value=False,
+        ), patch(
+            "run.render_comment_plan"
+        ), patch(
+            "run.console.status",
+            return_value=nullcontext(),
+        ), patch("run.section_title"), patch("run.console.print"):
+            run.run_comment_workflow(["/tmp/root"])
+
+        apply_review_comments.assert_not_called()
 
     def test_run_selected_action_dispatches_review_workflow(self) -> None:
         with patch("run.run_review_workflow") as run_review_workflow:


### PR DESCRIPTION
## What
This PR adds comment application functionality to the review tool, including support for dry-run mode. The changes enable users to apply comments to code reviews while optionally testing the operation without actually making changes.

## Why
The new comment application feature enhances the review tool's capabilities by allowing automated comment deployment. The dry-run support provides a safe way to test comment applications before actual execution, reducing the risk of unintended modifications to code reviews.

## Testing
No explicit test evidence provided in the commit. The functionality appears to be a new feature addition without accompanying test cases.

## Notes
This change introduces a new workflow for applying comments to code reviews and includes a dry-run flag for safe testing of the comment application process.